### PR TITLE
Update URL on search

### DIFF
--- a/src/Homepage.tsx
+++ b/src/Homepage.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import { Dispatch } from 'redux'
 import { connect } from 'react-redux'
+import history from './history'
 import { Page, PageHeader, PageSection } from '@patternfly/react-core'
 import SearchBar from './components/SearchBar'
 import { searchName } from './redux/actionCreators'
@@ -39,6 +40,7 @@ interface DispatchFromProps {
 
 const mapDispatchToProps = (dispatch: Dispatch): DispatchFromProps => ({
   fetchDetails: (name: string) => {
+    history.push(`/newfindmyrelative?q=${name}`, {})
     dispatch(searchName(name))
   }
 })

--- a/src/history.ts
+++ b/src/history.ts
@@ -1,0 +1,3 @@
+import { createBrowserHistory } from 'history'
+
+export default createBrowserHistory()


### PR DESCRIPTION
Update the URL with search query.

Example:
`/newfindmyrelative` on search turns to `/newfindmyrelative?q=name`

This PR depends on #30 , only consider commits starting from https://github.com/Emergency-Response-Demo/findmyrelative-frontend/pull/31/commits/b9aefc6474b4460548eef307d2804eab19fcd5e3 onwards