### PR TITLE
Display searched details

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "dependencies": {
     "@patternfly/react-core": "^3.134.2",
+    "@patternfly/react-tokens": "^2.7.25",
     "@types/jest": "24.0.23",
     "@types/mapbox-gl": "^1.7.0",
     "@types/node": "12.12.11",

--- a/src/Homepage.css
+++ b/src/Homepage.css
@@ -1,0 +1,3 @@
+.homepage-detail-section {
+    height: 83vh;
+}

--- a/src/Homepage.tsx
+++ b/src/Homepage.tsx
@@ -4,10 +4,12 @@ import { connect } from 'react-redux'
 import { Page, PageHeader, PageSection } from '@patternfly/react-core'
 import history from './history'
 import SearchBar from './components/SearchBar'
+import DetailSection from './components/DetailSection'
 import { searchName } from './redux/actionCreators'
 import { RootState } from './redux/reducers'
 import { Action } from './redux/reduxTypes'
 import '@patternfly/react-core/dist/styles/base.css'
+import './Homepage.css'
 
 interface HeaderProps {
   logo: { href: string; target: string };
@@ -32,6 +34,9 @@ export const Homepage: React.FC<HomepageProps> = ({ fetchDetails }) => (
   <Page header={<Header logo={appLogo} />}>
     <PageSection>
       <SearchBar onFormSubmit={fetchDetails} />
+    </PageSection>
+    <PageSection className="homepage-detail-section">
+      <DetailSection />
     </PageSection>
   </Page>
 )

--- a/src/components/DetailSection.tsx
+++ b/src/components/DetailSection.tsx
@@ -1,0 +1,28 @@
+import React from 'react'
+import { connect } from 'react-redux'
+import { RootState } from '../redux/reducers'
+import LoadingSpinner from './LoadingSpinner'
+import DisplayList from './DisplayList'
+import FailAlert from './FailAlert'
+
+type DisplaySectionProps = RootState['details'];
+
+const DisplaySection: React.FC<DisplaySectionProps> = ({
+  isFetching,
+  isSuccessful,
+  data
+}) => {
+  if (isFetching) {
+    return <LoadingSpinner />
+  }
+  if (isSuccessful) {
+    return <DisplayList data={data} />
+  }
+  return <FailAlert />
+}
+
+const mapStateToProps = (state: RootState): DisplaySectionProps => {
+  return state.details
+}
+
+export default connect(mapStateToProps)(DisplaySection)

--- a/src/components/DetailSection.tsx
+++ b/src/components/DetailSection.tsx
@@ -1,28 +1,30 @@
 import React from 'react'
-import { connect } from 'react-redux'
+import { connect, ConnectedProps } from 'react-redux'
 import { RootState } from '../redux/reducers'
 import LoadingSpinner from './LoadingSpinner'
 import DisplayList from './DisplayList'
 import FailAlert from './FailAlert'
 
-type DisplaySectionProps = RootState['details'];
+type DisplaySectionProps = PropsFromRedux;
 
-const DisplaySection: React.FC<DisplaySectionProps> = ({
+export const DisplaySection: React.FC<DisplaySectionProps> = ({
   isFetching,
   isSuccessful,
   data
 }) => {
-  if (isFetching) {
-    return <LoadingSpinner />
+  switch (true) {
+    case isFetching:
+      return <LoadingSpinner />
+    case isSuccessful:
+      return <DisplayList data={data} />
+    default:
+      return <FailAlert />
   }
-  if (isSuccessful) {
-    return <DisplayList data={data} />
-  }
-  return <FailAlert />
 }
 
-const mapStateToProps = (state: RootState): DisplaySectionProps => {
-  return state.details
-}
+const mapStateToProps = (state: RootState) => state.details
 
-export default connect(mapStateToProps)(DisplaySection)
+const connector = connect(mapStateToProps)
+type PropsFromRedux = ConnectedProps<typeof connector>;
+
+export default connector(DisplaySection)

--- a/src/components/DisplayList.tsx
+++ b/src/components/DisplayList.tsx
@@ -1,0 +1,82 @@
+import React from 'react'
+import {
+  Badge,
+  Card,
+  CardHeader,
+  CardBody,
+  Chip,
+  Divider,
+  EmptyState,
+  EmptyStateBody,
+  Label,
+  Split,
+  SplitItem,
+  Title,
+  Text,
+  TextContent
+} from '@patternfly/react-core'
+import { VictimDetail } from '../types'
+import MapDisplay from './MapDisplay'
+
+const EmptyList: React.FC = () => (
+  <EmptyState>
+    <Title size="lg">No results found</Title>
+    <EmptyStateBody>No matching names found.</EmptyStateBody>
+  </EmptyState>
+)
+
+interface DisplayTitleProps {
+  name: string;
+  status: string;
+}
+const DisplayTitle: React.FC<DisplayTitleProps> = ({ name, status }) => (
+  <CardHeader>
+    <Title size="xl" headingLevel="h3">
+      {name}
+    </Title>
+    <Chip isReadOnly>{status}</Chip>
+  </CardHeader>
+)
+
+interface DisplayListProps {
+  data: VictimDetail[];
+}
+const DisplayList: React.FC<DisplayListProps> = ({ data }) => {
+  if (data.length === 0) {
+    return <EmptyList />
+  }
+  return (
+    <>
+      {data.map((detail) => (
+        <Card key={detail.id}>
+          <DisplayTitle name={detail.victimName} status={detail.status} />
+          <Divider />
+          <CardBody>
+            <Split gutter="md">
+              <SplitItem>
+                <MapDisplay lat={detail.lat} lon={detail.lon} />
+              </SplitItem>
+              <SplitItem>
+                <TextContent>
+                  <Text>{`Reported on ${new Date(
+                    detail.timeStamp
+                  ).toDateString()}`}</Text>
+                  <Text>{`Phone: ${detail.victimPhoneNumber}`}</Text>
+                  <Chip isReadOnly>
+                    People
+                    <Badge isRead>{detail.numberOfPeople}</Badge>
+                  </Chip>
+                  {detail.medicalNeeded && (
+                    <Label isCompact>Medical attention needed</Label>
+                  )}
+                </TextContent>
+              </SplitItem>
+            </Split>
+          </CardBody>
+        </Card>
+      ))}
+    </>
+  )
+}
+
+export default DisplayList

--- a/src/components/FailAlert.tsx
+++ b/src/components/FailAlert.tsx
@@ -1,0 +1,12 @@
+import React from 'react'
+import { Alert } from '@patternfly/react-core'
+
+const FailAlert: React.FC = () => (
+  <Alert
+    variant="danger"
+    title="Error communicating with the backend API"
+    isInline
+  />
+)
+
+export default FailAlert

--- a/src/components/LoadingSpinner.tsx
+++ b/src/components/LoadingSpinner.tsx
@@ -1,0 +1,16 @@
+import React from 'react'
+import {
+  Title,
+  EmptyState,
+  EmptyStateIcon,
+  Spinner
+} from '@patternfly/react-core'
+
+const LoadingSpinner: React.FC = () => (
+  <EmptyState>
+    <EmptyStateIcon variant="container" component={Spinner} />
+    <Title size="lg">Loading</Title>
+  </EmptyState>
+)
+
+export default LoadingSpinner

--- a/src/components/MapDisplay.css
+++ b/src/components/MapDisplay.css
@@ -1,0 +1,4 @@
+#map {
+    width: 500px;
+    height: 400px;
+}

--- a/src/components/MapDisplay.tsx
+++ b/src/components/MapDisplay.tsx
@@ -1,8 +1,9 @@
 import React, { useEffect } from 'react'
 import mapboxgl from 'mapbox-gl'
+import { chart_global_danger_Color_100 } from '@patternfly/react-tokens'
 import './MapDisplay.css'
 
-const LIGHT_RED = '#F86C6B'
+const LIGHT_RED = chart_global_danger_Color_100.value
 
 interface MapDisplayProps {
   lat: string;
@@ -20,7 +21,7 @@ const MapDisplay: React.FC<MapDisplayProps> = ({ lat, lon }) => {
       zoom: 10
     })
     new mapboxgl.Marker({ color: LIGHT_RED }).setLngLat(lngLat).addTo(map)
-  })
+  }, [lat, lon])
   return <div id="map"></div>
 }
 

--- a/src/components/MapDisplay.tsx
+++ b/src/components/MapDisplay.tsx
@@ -1,0 +1,27 @@
+import React, { useEffect } from 'react'
+import mapboxgl from 'mapbox-gl'
+import './MapDisplay.css'
+
+const LIGHT_RED = '#F86C6B'
+
+interface MapDisplayProps {
+  lat: string;
+  lon: string;
+}
+
+const MapDisplay: React.FC<MapDisplayProps> = ({ lat, lon }) => {
+  useEffect(() => {
+    const lngLat = [Number(lon), Number(lat)] as [number, number]
+    mapboxgl.accessToken = process.env.REACT_APP_MAPBOX_TOKEN || ''
+    const map = new mapboxgl.Map({
+      container: 'map',
+      style: 'mapbox://styles/mapbox/streets-v11',
+      center: lngLat,
+      zoom: 10
+    })
+    new mapboxgl.Marker({ color: LIGHT_RED }).setLngLat(lngLat).addTo(map)
+  })
+  return <div id="map"></div>
+}
+
+export default MapDisplay

--- a/src/redux/reducers/details.ts
+++ b/src/redux/reducers/details.ts
@@ -1,3 +1,4 @@
+import { VictimDetail } from '../../types'
 import {
   REQUEST_DETAILS,
   RECIEVE_DETAILS,
@@ -5,14 +6,22 @@ import {
   RecieveDetailsType
 } from '../reduxTypes'
 
-const initialState = {
+interface StateType {
+  isFetching: boolean;
+  isSuccessful: boolean;
+  data: VictimDetail[];
+}
+const initialState: StateType = {
   isFetching: false,
   isSuccessful: true,
   data: []
 }
 
 type ActionType = RequestDetailsType & RecieveDetailsType;
-export function detailsReducer (state = initialState, action: ActionType) {
+export function detailsReducer (
+  state = initialState,
+  action: ActionType
+): StateType {
   switch (action.type) {
     case REQUEST_DETAILS:
       return { ...state, isFetching: true }
@@ -21,10 +30,11 @@ export function detailsReducer (state = initialState, action: ActionType) {
         return {
           ...state,
           isFetching: false,
+          isSuccessful: true,
           data: action.payload.data
         }
       } else {
-        return { ...state, isFetching: false, data: [] }
+        return { ...state, isSuccessful: false, isFetching: false, data: [] }
       }
     default:
       return state


### PR DESCRIPTION
Displays fetched details from the redux store:

- Display message when no details are found:
![empty](https://user-images.githubusercontent.com/20013884/74422416-9323ef00-4e74-11ea-94e5-b2ac27b7bf6b.png)
- Show spinner when details are being fetched:
![loading](https://user-images.githubusercontent.com/20013884/74422733-147b8180-4e75-11ea-8665-475b7b15bebb.png)
- Display fetched details using patternfly `Card`:
![assign](https://user-images.githubusercontent.com/20013884/74422456-a46cfb80-4e74-11ea-955d-a1b4866e866d.png)
- Show error message on failed request:
![error](https://user-images.githubusercontent.com/20013884/74422477-ae8efa00-4e74-11ea-842b-482655b232ba.png)