### PR TITLE
Use incident ID to keep track of rendered maps

### DIFF
--- a/src/components/DisplayList.tsx
+++ b/src/components/DisplayList.tsx
@@ -54,7 +54,7 @@ const DisplayList: React.FC<DisplayListProps> = ({ data }) => {
           <CardBody>
             <Split gutter="md">
               <SplitItem>
-                <MapDisplay lat={detail.lat} lon={detail.lon} />
+                <MapDisplay id={detail.id} lat={detail.lat} lon={detail.lon} />
               </SplitItem>
               <SplitItem>
                 <TextContent>

--- a/src/components/DisplayList.tsx
+++ b/src/components/DisplayList.tsx
@@ -47,14 +47,14 @@ const DisplayList: React.FC<DisplayListProps> = ({ data }) => {
   }
   return (
     <>
-      {data.map((detail) => (
-        <Card key={detail.id}>
+      {data.map(({ id, lat, lon, ...detail }) => (
+        <Card key={id}>
           <DisplayTitle name={detail.victimName} status={detail.status} />
           <Divider />
           <CardBody>
             <Split gutter="md">
               <SplitItem>
-                <MapDisplay id={detail.id} lat={detail.lat} lon={detail.lon} />
+                <MapDisplay id={id} latitude={lat} longitude={lon} />
               </SplitItem>
               <SplitItem>
                 <TextContent>

--- a/src/components/MapDisplay.css
+++ b/src/components/MapDisplay.css
@@ -1,4 +1,4 @@
-#map {
+.map {
     width: 500px;
     height: 400px;
 }

--- a/src/components/MapDisplay.tsx
+++ b/src/components/MapDisplay.tsx
@@ -5,9 +5,15 @@ import './MapDisplay.css'
 
 const LIGHT_RED = chart_global_danger_Color_100.value
 
-const mapsList: { [id: string]: mapboxgl.Map } = {}
+interface MapsListType {
+  [id: string]: mapboxgl.Map;
+}
+const mapsList: MapsListType = {}
 
-export const addMarkerToMap = (mapId: string, lngLat: [number, number]): void => {
+export const addMarkerToMap = (
+  mapId: string,
+  lngLat: [number, number]
+): void => {
   new mapboxgl.Marker({ color: LIGHT_RED })
     .setLngLat(lngLat)
     .addTo(mapsList[mapId])
@@ -15,13 +21,13 @@ export const addMarkerToMap = (mapId: string, lngLat: [number, number]): void =>
 
 interface MapDisplayProps {
   id: string;
-  lat: string;
-  lon: string;
+  latitude: string;
+  longitude: string;
 }
 
-const MapDisplay: React.FC<MapDisplayProps> = ({ id, lat, lon }) => {
+const MapDisplay: React.FC<MapDisplayProps> = ({ id, latitude, longitude }) => {
   useEffect(() => {
-    const lngLat = [Number(lon), Number(lat)] as [number, number]
+    const lngLat = [Number(longitude), Number(latitude)] as [number, number]
     mapboxgl.accessToken = process.env.REACT_APP_MAPBOX_TOKEN || ''
     const map = new mapboxgl.Map({
       container: id,
@@ -31,7 +37,7 @@ const MapDisplay: React.FC<MapDisplayProps> = ({ id, lat, lon }) => {
     })
     mapsList[id] = map
     addMarkerToMap(id, lngLat)
-  }, [id, lat, lon])
+  }, [id, latitude, longitude])
   return <div className="map" id={id}></div>
 }
 

--- a/src/components/MapDisplay.tsx
+++ b/src/components/MapDisplay.tsx
@@ -5,24 +5,34 @@ import './MapDisplay.css'
 
 const LIGHT_RED = chart_global_danger_Color_100.value
 
+const mapsList: { [id: string]: mapboxgl.Map } = {}
+
+export const addMarkerToMap = (mapId: string, lngLat: [number, number]): void => {
+  new mapboxgl.Marker({ color: LIGHT_RED })
+    .setLngLat(lngLat)
+    .addTo(mapsList[mapId])
+}
+
 interface MapDisplayProps {
+  id: string;
   lat: string;
   lon: string;
 }
 
-const MapDisplay: React.FC<MapDisplayProps> = ({ lat, lon }) => {
+const MapDisplay: React.FC<MapDisplayProps> = ({ id, lat, lon }) => {
   useEffect(() => {
     const lngLat = [Number(lon), Number(lat)] as [number, number]
     mapboxgl.accessToken = process.env.REACT_APP_MAPBOX_TOKEN || ''
     const map = new mapboxgl.Map({
-      container: 'map',
+      container: id,
       style: 'mapbox://styles/mapbox/streets-v11',
       center: lngLat,
       zoom: 10
     })
-    new mapboxgl.Marker({ color: LIGHT_RED }).setLngLat(lngLat).addTo(map)
-  }, [lat, lon])
-  return <div id="map"></div>
+    mapsList[id] = map
+    addMarkerToMap(id, lngLat)
+  }, [id, lat, lon])
+  return <div className="map" id={id}></div>
 }
 
 export default MapDisplay


### PR DESCRIPTION
- Use Incident ID instead of hardcoded ID for map divs
- Keep dict of all the rendered maps on the page
- Expose function which allows adding of additional markers to maps using their IDs

Fixes #38 